### PR TITLE
fix: welcome screen had wrong color in description

### DIFF
--- a/src/pages/signup_welcome.js
+++ b/src/pages/signup_welcome.js
@@ -4,12 +4,15 @@ import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 
 import { Routes } from 'lib/constants/routes';
+import { Color, Space } from 'lib/theme';
 
 import Page from 'components/layouts/Page';
 import ConfirmationWrapper from 'components/Confirmation/ConfirmationWrapper';
 import Text from 'components/Text';
 import { TEXT_TYPE } from 'components/Text/constants';
 import { PrimaryButton } from 'components/Button';
+
+const styles = { color: Color.GRAY_75, marginBottom: Space.S50 };
 
 function LoginWelcome() {
   const history = useHistory();
@@ -22,7 +25,7 @@ function LoginWelcome() {
   return (
     <Page>
       <ConfirmationWrapper noIcon title={t('welcome.signup.title')}>
-        <Text as="p" type={TEXT_TYPE.BODY_2}>
+        <Text as="p" type={TEXT_TYPE.BODY_2} css={styles}>
           {t('welcome.signup.description')}
         </Text>
         <PrimaryButton onClick={handleSubmit}>


### PR DESCRIPTION
* Updated text colors for description on welcome page where email gets verified.

old ↓
<img width="617" alt="Screenshot 2020-05-19 19 37 47" src="https://user-images.githubusercontent.com/1128500/82399355-ccd33b80-9a09-11ea-8f3e-92f795e09cb5.png">

new ↓
<img width="580" alt="Screenshot 2020-05-19 19 47 52" src="https://user-images.githubusercontent.com/1128500/82399359-cf359580-9a09-11ea-8b2f-417019f5e946.png">
